### PR TITLE
Simplify logging to handle concurrent usgae.

### DIFF
--- a/modularodm/storage/mongostorage.py
+++ b/modularodm/storage/mongostorage.py
@@ -172,7 +172,8 @@ class MongoStorage(Storage):
     """
     QuerySet = MongoQuerySet
 
-    def __init__(self, db, collection):
+    def __init__(self, db, collection, log_level=None):
+        super(MongoStorage, self).__init__(log_level)
         self.db = db
         self.collection = collection
 
@@ -212,7 +213,7 @@ class MongoStorage(Storage):
         )
 
     def get(self, primary_name, key):
-        return self.store.find_one({primary_name : key})
+        return self.store.find_one({primary_name: key})
 
     def insert(self, primary_name, key, value):
         if primary_name not in value:
@@ -249,5 +250,4 @@ class MongoStorage(Storage):
         pass
 
     def __repr__(self):
-        return self.find()
-
+        return repr(self.store)

--- a/modularodm/storage/picklestorage.py
+++ b/modularodm/storage/picklestorage.py
@@ -136,14 +136,14 @@ class PickleStorage(Storage):
 
     QuerySet = PickleQuerySet
 
-    def __init__(self, collection_name,  prefix='db_', ext='pkl'):
+    def __init__(self, collection_name,  prefix='db_', ext='pkl', log_level=None):
         """Build pickle file name and load data if exists.
 
         :param collection_name: Collection name
         :param prefix: File prefix.
         :param ext: File extension.
-
         """
+        super(PickleStorage, self).__init__(log_level)
         # Build filename
         filename = collection_name + '.' + ext
         if prefix:

--- a/tests/backrefs/test_attribute_syntax.py
+++ b/tests/backrefs/test_attribute_syntax.py
@@ -1,13 +1,13 @@
+import mock
 import unittest
+from nose.tools import *  # noqa
 
 from modularodm import fields
-from modularodm.storedobject import ContextLogger
 from modularodm import StoredObject
 from modularodm.exceptions import ModularOdmException
 
-from tests.base import (
-    ModularOdmTestCase
-)
+from tests.base import ModularOdmTestCase
+
 
 class OneToManyFieldTestCase(ModularOdmTestCase):
 
@@ -72,26 +72,20 @@ class OneToManyFieldTestCase(ModularOdmTestCase):
     def test_dunder_br_laziness(self):
         StoredObject._clear_caches()
 
-        with ContextLogger() as c:
+        with mock.patch.object(self.Foo._storage[0], 'get') as mock_find:
             # get the Bar object
             bar = self.Bar.find_one()
             # access the ForeignList
             bar.foo__my_foos
 
-            # Two calls so far - .find_one() and .find()
-            self.assertNotIn(
-                'foo',
-                [k[0] for k, v in c.report().iteritems()],
-            )
+            assert_false(mock_find.called)
 
             # access a member of the ForeignList, forcing that member to load
             bar.foo__my_foos[0]
 
             # now there should be a call to Foo.get()
-            self.assertEqual(
-                c.report()[('foo', 'get')][0],
-                1
-            )
+            assert_true(mock_find.called)
+
 
 class OneToManyAbstractFieldTestCase(ModularOdmTestCase):
 
@@ -164,24 +158,16 @@ class OneToManyAbstractFieldTestCase(ModularOdmTestCase):
 
     def test_dunder_br_laziness(self):
         StoredObject._clear_caches()
-
-        with ContextLogger() as c:
+        with mock.patch.object(self.Foo._storage[0], 'get') as mock_find:
             # get the Bar object
             bar = self.Bar.find_one()
             # access the ForeignList
             bar.foo__my_foos
 
-            # Two calls so far - .find_one() and .find()
-            self.assertNotIn(
-                'foo',
-                [k[0] for k, v in c.report().iteritems()],
-            )
+            assert_false(mock_find.called)
 
             # access a member of the ForeignList, forcing that member to load
             bar.foo__my_foos[0]
 
             # now there should be a call to Foo.get()
-            self.assertEqual(
-                c.report()[('foo', 'get')][0],
-                1
-            )
+            assert_true(mock_find.called)


### PR DESCRIPTION
# Purpose

The current logging code tries to split logs by action and calling `StoredObject` subclass, which relies on state-sharing that doesn't work well with concurrent usage. This patch simplifies logging in a way that will work with concurrency.
# Changes
- Rewrite logging to make it simpler
- Don't rely on logging for laziness tests
# Side effects

The `Storage` class now accepts a `log_level` argument that defaults to `None`. To enable logging, pass a valid log level to `Storage` (e.g. `logging.info`).
